### PR TITLE
Fix macOS rendering

### DIFF
--- a/src/linux_main.c
+++ b/src/linux_main.c
@@ -116,9 +116,13 @@ int main(int argc, char** argv) {
 //        window_flags |= SDL_WINDOW_MAXIMIZED;
 //    }
     window_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
-    SDL_Renderer* renderer;
-    SDL_Window* window;
-    if (SDL_CreateWindowAndRenderer(desired_window_width, desired_window_height, window_flags, &window, &renderer) != 0) {
+    SDL_Window* window = SDL_CreateWindow("Rayverse", 
+                                          SDL_WINDOWPOS_CENTERED, 
+                                          SDL_WINDOWPOS_CENTERED,
+                                          desired_window_width, 
+                                          desired_window_height, 
+                                          window_flags);
+    if (!window) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window and renderer: %s", SDL_GetError());
         return 3;
     }

--- a/src/linux_opengl.c
+++ b/src/linux_opengl.c
@@ -149,7 +149,16 @@ bool linux_init_opengl(app_state_t* app_state) {
         fatal_error();
     }
 #endif
+    // load the shader that renders the surface to the screen
+    basic_shader.program = load_basic_shader_program(vertex_shader_source, fragment_shader_source);
+    basic_shader.u_texture0 = get_uniform(basic_shader.program, "texture0");
+    basic_shader.attrib_location_pos = get_attrib(basic_shader.program, "pos");
+    basic_shader.attrib_location_tex_coord = get_attrib(basic_shader.program, "tex_coord");
 
+    glUseProgram(basic_shader.program);
+    glUniform1i(basic_shader.u_texture0, 0);
+
+    init_draw_normalized_quad();
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &app_state->opengl.max_texture_size);
 
 	glEnable(GL_TEXTURE_2D);
@@ -163,16 +172,7 @@ bool linux_init_opengl(app_state_t* app_state) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    // load the shader that renders the surface to the screen
-    basic_shader.program = load_basic_shader_program(vertex_shader_source, fragment_shader_source);
-    basic_shader.u_texture0 = get_uniform(basic_shader.program, "texture0");
-    basic_shader.attrib_location_pos = get_attrib(basic_shader.program, "pos");
-    basic_shader.attrib_location_tex_coord = get_attrib(basic_shader.program, "tex_coord");
 
-    glUseProgram(basic_shader.program);
-    glUniform1i(basic_shader.u_texture0, 0);
-
-    init_draw_normalized_quad();
 
 	return true;
 }


### PR DESCRIPTION
Fixes some issue where compiling with the current main branch would give a segmentation fault due to some issues with SDL rendering and using glGetIntegerv a bit too early for macOS' liking.
Should still work on Linux (don't have a Linux machine to test it), may need some testing there.